### PR TITLE
AIFix Issue 1134: \n get escaped to \\n in "Final Answer"

### DIFF
--- a/langchain/src/agents/chat/outputParser.ts
+++ b/langchain/src/agents/chat/outputParser.ts
@@ -7,7 +7,7 @@ export class ChatAgentOutputParser extends AgentActionOutputParser {
   async parse(text: string) {
     if (text.includes(FINAL_ANSWER_ACTION) || !text.includes(`"action":`)) {
       const parts = text.split(FINAL_ANSWER_ACTION);
-      const output = parts[parts.length - 1].trim();
+      const output = parts[parts.length - 1].trim().replace(/\\n/g, "\n");
       return { returnValues: { output }, log: text } satisfies AgentFinish;
     }
 
@@ -19,7 +19,7 @@ export class ChatAgentOutputParser extends AgentActionOutputParser {
       return {
         tool: response.action,
         toolInput: response.action_input,
-        log: text,
+        log: text.replace(/\\n/g, "\n"),
       };
     } catch {
       throw new Error(

--- a/langchain/src/agents/chat_convo/outputParser.ts
+++ b/langchain/src/agents/chat_convo/outputParser.ts
@@ -15,6 +15,8 @@ export class ChatConversationalAgentOutputParser extends AgentActionOutputParser
       jsonOutput = jsonOutput.slice(0, lastIndex).trimEnd();
     }
 
+    jsonOutput = jsonOutput.replace(/\\n/g, "\n"); // Fix for escaped new lines
+
     const response = JSON.parse(jsonOutput);
 
     const { action, action_input } = response;


### PR DESCRIPTION
AI-Generated Fix for Issue 1134 opened by titocosta visible at https://api.github.com/repos/hwchase17/langchainjs/issues/1134
State: open
Summary: This Github issue pertains to the use of agents for simple conversational questions. The issue is that when the \n character is used, it gets escaped to \\n, which results in no new lines being shown and the \n being written out instead.